### PR TITLE
Set the permissions on dirs that nexus expects to be able to write.

### DIFF
--- a/nexus/init.sls
+++ b/nexus/init.sls
@@ -43,6 +43,20 @@ unpack-nexus-tarball:
       - file: {{ nexus.prefix }}
       - file: {{ nexus.download_dir }}
 
+{{ nexus.real_home }}/logs:
+  file.directory:
+    - user: nexus
+    - group: nexus
+    - require:
+      - cmd: unpack-nexus-tarball
+
+{{ nexus.real_home }}/tmp:
+  file.directory:
+    - user: nexus
+    - group: nexus
+    - require:
+      - cmd: unpack-nexus-tarball
+
 {{ nexus.download_dir }}/sonatype_work:
   file.absent
 


### PR DESCRIPTION
Thanks for this work. Out of the box the nexus server wouldn't start because it needed to be able to write to the tmp and logs directories, but it couldn't because they were owned by root.

My pillar configuration was:
```
nexus:
  version: 2.11.3
  prefix: /mnt/nexus
  workdir: /mnt/nexus/sonatype_work
  port: 8081
  piddir: /var/run/nexus
  username: nexus
```