### PR TITLE
Group setting, plus removed hard-coded username

### DIFF
--- a/nexus/init.sls
+++ b/nexus/init.sls
@@ -19,8 +19,8 @@ include:
 {{ nexus.workdir }}/nexus:
   file.directory:
     - makedirs: True
-    - user: nexus
-    - group: nexus
+    - user: {{ nexus.username }}
+    - group: {{ nexus.username }}
     - recurse:
       - user
       - group
@@ -28,8 +28,8 @@ include:
 {{ nexus.piddir }}:
   file.directory:
     - makedirs: True
-    - user: nexus
-    - group: nexus
+    - user: {{ nexus.username }}
+    - group: {{ nexus.username }}
     - recurse:
       - user
       - group

--- a/nexus/init.sls
+++ b/nexus/init.sls
@@ -20,7 +20,7 @@ include:
   file.directory:
     - makedirs: True
     - user: {{ nexus.username }}
-    - group: {{ nexus.username }}
+    - group: {{ nexus.group }}
     - recurse:
       - user
       - group
@@ -29,7 +29,7 @@ include:
   file.directory:
     - makedirs: True
     - user: {{ nexus.username }}
-    - group: {{ nexus.username }}
+    - group: {{ nexus.group }}
     - recurse:
       - user
       - group
@@ -45,15 +45,15 @@ unpack-nexus-tarball:
 
 {{ nexus.real_home }}/logs:
   file.directory:
-    - user: nexus
-    - group: nexus
+    - user: {{ nexus.username }}
+    - group: {{ nexus.group }}
     - require:
       - cmd: unpack-nexus-tarball
 
 {{ nexus.real_home }}/tmp:
   file.directory:
-    - user: nexus
-    - group: nexus
+    - user: {{ nexus.username }}
+    - group: {{ nexus.group }}
     - require:
       - cmd: unpack-nexus-tarball
 

--- a/nexus/settings.sls
+++ b/nexus/settings.sls
@@ -16,6 +16,7 @@
 {%- set workdir   = g.get('workdir', p.get('workdir', '/srv/nexus/sonatype_work')) %}
 {%- set piddir    = g.get('piddir', p.get('piddir', '/var/run/nexus')) %}
 {%- set username  = g.get('username', p.get('username', 'nexus')) %}
+{%- set group     = g.get('group', p.get('group', 'nexus')) %}
 {%- set port      = gc.get('port', pc.get('port', '8081')) %}
 {%- set server_name = gc.get('server_name', pc.get('server_name', grains.get('fqdn'))) %}
 
@@ -27,6 +28,7 @@
                           'workdir'        : workdir,
                           'piddir'         : piddir,
                           'username'       : username,
+                          'group'          : group,
                           'port'           : port,
                           'source_url'     : source_url,
                           'home'           : home,

--- a/pillar.example
+++ b/pillar.example
@@ -5,3 +5,4 @@ nexus:
   port: 8081
   piddir: /var/run/nexus
   username: nexus
+  group: nexus


### PR DESCRIPTION
I noticed that the username could be set in the pillar but it was hard-coded in init.sls. Fixed.

Also separated the group as another pillar setting.