### PR TITLE
An updated formula to be compatible with nexus 3.11.0-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nexus OSS Repository Saltstack Formula
-This Saltstack formula will install Nexus OSS Repository onto any linux (tested with debian jessie).
+This Saltstack formula will install Nexus OSS Repository onto any linux (tested with debian jessie, CentOS 5,6,7).
 
 **Requires Nexus Sonatype Version 3 and above.**
 
@@ -21,7 +21,7 @@ In your formula matching sls just add
 Questions regarding "how to configure nexus" take a look at the sonatype documentation website. http://books.sonatype.com/nexus-book/reference3/index.html
 
 ## Prerequisites
-1.) Requires Java
+1.) Requires Java JRE
 
 2.) Knowledge in Nexus OSS
 
@@ -33,7 +33,7 @@ There is also `nexus.v3.copylivedata` which will copy data from another host, to
 Needs an existing ssh key on the host system.
 
 ## Defaults
-1.) HTTPS will be configured and a self signed certificate is going to be created.
+1.) HTTPS will be configured and a self signed certificate is going to be created if `applicationportssl` is uncommented.
 
 2.) The passwords for the java keystore is **neither encrypted nor obscured** in the `jetty-https.xml`.
 
@@ -53,7 +53,7 @@ Nexus OSS can be installed anywhere on linux. Per default it will be installed o
 
 `nexus-versionnumber` is created while extracting, can be set via `install.path` in pillar
 
-`sonatype-work` is created while extracting, can be set via `install.datapath` in pillar
+`sonatype-work` is created while extracting, can be set via `install.datapath` in pillar symlink in `install.path` will be created
 
 ### Configurationfiles
 The following file will be created and modified via salt
@@ -82,9 +82,6 @@ Formula to set up and configure a Sonatype Nexus server.
         local:
             - ``nexus``
 
-Downloads the tarball in version nexus:version (currently defaults to 2.8.0) from sonatype configured as either a pillar or grain. 
-Then unpacks the archive into nexus:prefix (defaults to /srv/nexus).
-Depends on the sun-java-formula for its JDK.
-
-Tested on RedHat/CentOS 5.X or RedHat/CentOS 6.X.
-
+Downloads the tarball in version nexus:version (currently defaults to 3.11.0-01) from sonatype configured as either a pillar or grain. 
+Then unpacks the archive into nexus:prefix (defaults to /opt/nexus).
+Depends on the sun-java-formula for its JDK/JRE. Tested with jre1.8.0_172.

--- a/nexus/v3/defaults.yaml
+++ b/nexus/v3/defaults.yaml
@@ -20,9 +20,11 @@ nexus:
     home: '/home/nexus'
   file:
     nexus:
+      limit: '65536'
       properties:
         applicationport: '8081'
-        applicationportssl: '8443'
+        # By uncommenting 'applicationportssl' Enabling this will start jetty in SSL mode
+        #applicationportssl: '8443'
         applicationhost: '0.0.0.0'
         nexuscontextpath: '/'
         nexusfeatures:

--- a/nexus/v3/files/jetty-https.xml.jinja
+++ b/nexus/v3/files/jetty-https.xml.jinja
@@ -73,7 +73,6 @@
         <Set name="idleTimeout"><Property name="jetty.https.timeout" default="30000"/></Set>
         <Set name="soLingerTime"><Property name="jetty.https.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.https.acceptorPriorityDelta" default="0"/></Set>
-        <Set name="selectorPriorityDelta"><Property name="jetty.https.selectorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.https.acceptQueueSize" default="0"/></Set>
       </New>
     </Arg>

--- a/nexus/v3/files/nexus.properties.jinja
+++ b/nexus/v3/files/nexus.properties.jinja
@@ -1,16 +1,17 @@
 # Jetty section
+
 application-port= {{ nexus.file.nexus.properties.applicationport }}
- {% if nexus.file.nexus.properties.applicationportssl is defined %}
-     application-port-ssl= {{ nexus.file.nexus.properties.applicationportssl }}
- {% endif %}
+{%- if nexus.file.nexus.properties.applicationportssl is defined -%}
+application-port-ssl= {{ nexus.file.nexus.properties.applicationportssl }}
+{% endif %}
 application-host={{ nexus.file.nexus.properties.applicationhost }}
- {% if nexus.file.nexus.properties.applicationportssl is defined %}
-    nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-http-redirect-to-https.xml
- {% else %}
-    nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml
- {% endif %}
+{% if nexus.file.nexus.properties.applicationportssl is defined -%}
+nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-http-redirect-to-https.xml
+{% else -%}
+nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml
+{% endif -%}
 nexus-context-path={{ nexus.file.nexus.properties.nexuscontextpath }}
-{% if nexus.file.nexus.properties.sessiontimeout is defined %}
+{% if nexus.file.nexus.properties.sessiontimeout is defined -%}
 shiro.globalSessionTimeout= {{ nexus.file.nexus.properties.sessiontimeout }}
 {% endif %}
 

--- a/nexus/v3/files/nexus.service.jinja
+++ b/nexus/v3/files/nexus.service.jinja
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
+LimitNOFILE={{ nexus.file.nexus.limit }}
 ExecStart={{ nexus.install.path }}/nexus/bin/nexus start
 ExecStop={{ nexus.install.path }}/nexus/bin/nexus stop
 User={{ nexus.user.name }}

--- a/nexus/v3/files/nexus.vmoptions.jinja
+++ b/nexus/v3/files/nexus.vmoptions.jinja
@@ -1,3 +1,3 @@
-{% for addjavavariable in salt['pillar.get']('nexus:file:nexus:vmoptions:addjavavariables', []) %}
+{% for addjavavariable in salt['pillar.get']('nexus:file:nexus:vmoptions:addjavavariables', []) -%}
 -{{ addjavavariable }}
-{% endfor %}
+{% endfor -%}

--- a/pillar-v3.example
+++ b/pillar-v3.example
@@ -1,15 +1,17 @@
-# -*- coding: utf-8 -*-
-# vim: ft=yaml
+# Requires: https://github.com/saltstack-formulas/nexus-formula
 nexus:
+  java:
+  #JAVA_HOME for bin/keytool
+    home: '/usr/lib/java'
   download:
   #version is only used for creating the directories. 
-    version: '3.4.0-02'
+    version: '3.11.0-01'
   #add the http download path
-    httppath: 'https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-3.4.0-02-unix.tar.gz'
+    httppath: 'https://sonatype-download.global.ssl.fastly.net/repository/repositoryManager/3/nexus-3.11.0-01-unix.tar.gz'
   #add the hash, you can use ASC, SHA1, and MD5 as provided via sonatype
-    hash: 'https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-3.4.0-02-unix.tar.gz.sha1'
+    hash: 'http://download.sonatype.com/nexus/3/latest-unix.tar.gz.sha1'
   #add the path where the nexus archiv should be downloaded and extracted to.
-    hostpath: '/home/nexus/download'
+    hostpath: '/tmp/download'
   #add if copylivedata is used as a state
   datacopy:
   #the user used for scp access
@@ -23,7 +25,7 @@ nexus:
   # only add e.g. /opt no trailing /
     path: '/opt'
   # add the datapath /opt/sonatype-work no trailing /
-    datapath: '/opt/sonatype-work'
+    datapath: '/srv/sonatype-work'
   user:
   # generate a system user with the name 'nexus'
     name: 'nexus'
@@ -35,12 +37,14 @@ nexus:
     home: '/home/nexus'
   file:
     nexus:
+  # Limits on the number of file descriptors
+      limit: '65536'
   # change the 'nexus.properties' file in /opt/sonatype-work/etc/nexus.properties
       properties:
   # non https port
         applicationport: '8081'
   # https port, if set, automatically will start with https
-        applicationportssl: '8443'
+      # applicationportssl: '8443'
   # sets applicationhost     
         applicationhost: '0.0.0.0'
   # sets nexuscontextpath
@@ -49,13 +53,13 @@ nexus:
   # configure the jetty file
         https:
   # add the keystorename without '.jks' 
-          keystorepath: 'dummy'
+          keystorepath: "keystore"
   # add the keystorepassword which is used for the self signed certificate
-          keystorepassword: 'dummy1234'
+          keystorepassword: 'dummy'
   # add the keystoremanagerpassword, which is used for creating new certificates in the java keystore
-          keymanagerpassword: 'dummy1234'
+          keymanagerpassword: 'dummy'
   # add truststorepath
-          truststorepath: 'dummy'
+          truststorepath: "truststore"
   # add truststorepassword
           truststorepassword: 'dummy'
   # following informations used for generating self signed certificate
@@ -63,7 +67,7 @@ nexus:
             commonname: 'dummy'
             ou: 'dummy'
             organisation: 'dummy'
-            country: 'AT'
+            country: 'ZZ'
   # set run option in 'nexus.rc'
       rc:
         runasuser: 'nexus'
@@ -84,6 +88,5 @@ nexus:
           - 'Djava.util.logging.config.file=etc/karaf/java.util.logging.properties'
           - 'Dkaraf.data=../sonatype-work/nexus3'
           - 'Djava.io.tmpdir=../sonatype-work/nexus3/tmp'
-          - "Dkaraf.s'tartLocalConsole=false"
+          - 'Dkaraf.startLocalConsole=false'
           - 'Djava.util.prefs.userRoot=/home/nexus/.java'
-        


### PR DESCRIPTION
- An updated formula to be compatible with Nexus 3.11.0-01
- Added custom customizable data-folder (symlink)
- Added file descriptor limit for service running nexus
- Added option to set java_home path for bin/keytool
- Avoid to run nexus OOB with SSL as it causing more issues
- Fixed typos, wrong paths, formating
- Removed selectorPriorityDelta property as advised in Nexus documentation