### PR TITLE
fix(install): add missing require for nexus_extract

### DIFF
--- a/nexus/v3/install.sls
+++ b/nexus/v3/install.sls
@@ -53,6 +53,8 @@ nexus_mark_version_as_installed:
   cmd.run:
     - name: 'touch {{ nexus.download.hostpath }}/nexus-{{ nexus.download.version }}.txt'
     - unless: 'test -f {{ nexus.download.hostpath }}/nexus-{{ nexus.download.version }}.txt'
+    - require:
+      - archive: nexus_extract_home_download
 
 nexus_install_opt_sonatype_etc:
     file.directory:


### PR DESCRIPTION
Prevent installed marker creation if archive extract failed for some reasons